### PR TITLE
Use peg.el to parse snippets rather than the giant regex and matches

### DIFF
--- a/eglot-tempel-tests.el
+++ b/eglot-tempel-tests.el
@@ -37,6 +37,8 @@
   ""
   (should (equal (list "func(" 'p ")" 'q) (eglot-tempel--convert "func($1)")))
   (should (equal (list "func(" 'p " " 'p ")" 'q) (eglot-tempel--convert "func($1 $2)")))
+  (should (equal (list "func(" 'p " " 'p ")" 'q) (eglot-tempel--convert "func(${1} $2)")))
+  (should (equal (list "func(" 'p " " 'p ")" 'q) (eglot-tempel--convert "func(${1} ${2})")))
   (should (equal (list "func(" 'p " " 'p " " 'p")" 'q) (eglot-tempel--convert "func($1 $2 $3)"))))
 
 (ert-deftest test-named ()
@@ -47,19 +49,24 @@
 
 (ert-deftest test-end ()
   ""
-  (should (equal (list "func(" 'p ")" 'q) (eglot-tempel--convert "func($1)$0")))
-  (should (equal (list "func(" 'p ")" 'q ";") (eglot-tempel--convert "func($1)$0;"))))
+  (should (equal (list "func(" 'p ")" 'q 'q) (eglot-tempel--convert "func($1)$0")))
+  (should (equal (list "func(" 'p ")" 'q ";" 'q) (eglot-tempel--convert "func($1)$0;"))))
 
 (ert-deftest test-mixed ()
   ""
-  (should (equal (list "func(" (list 'p "named" "1") ")" 'q) (eglot-tempel--convert "func(${1:named})")))
-  (should (equal (list "func(" (list 'p "first" "1") " " 'p ")" 'q)
+  (should (equal (list "func(" (list 'p "named" 1) ")" 'q) (eglot-tempel--convert "func(${1:named})")))
+  (should (equal (list "func(" (list 'p "first" 1) " " 'p ")" 'q 'q)
 		       (eglot-tempel--convert "func(${1:first} $2)$0"))))
 
 (ert-deftest test-dots ()
   ""
-  (should (equal (list "func(" (list 'p "named" "1") " ...)" 'q) (eglot-tempel--convert "func(${1:named} ...)")))
-  (should (equal (list "func(" (list 'p "first" "1") " " 'p " ...)" 'q)
+  (should (equal (list "func(" (list 'p "named" 1) " ...)" 'q) (eglot-tempel--convert "func(${1:named} ...)")))
+  (should (equal (list "func(" (list 'p "first" 1) " " 'p " ...)" 'q 'q)
 		       (eglot-tempel--convert "func(${1:first} $2 ...)$0"))))
+
+(ert-deftest test-choice ()
+  ""
+  (should (equal (list "func(" (list 'p "one,two,three" 1) ")" 'q)
+		 (eglot-tempel--convert "func(${1|one,two,three|})"))))
 
 ;;; eglot-tempel-tests.el ends here

--- a/eglot-tempel.el
+++ b/eglot-tempel.el
@@ -5,7 +5,7 @@
 ;; Author: Jeff Walsh <fejfighter@gmail.com>
 ;; Created: 2022
 ;; Version: 0.7
-;; Package-Requires: ((eglot "1.9")  (tempel "0.5") (emacs "24.4") (peg "1.0.1"))
+;; Package-Requires: ((eglot "1.9")  (tempel "0.5") (emacs "29.1") (peg "1.0.1"))
 ;; Keywords: convenience, languages, tools
 ;; URL: https://github.com/fejfighter/eglot-tempel
 

--- a/eglot-tempel.el
+++ b/eglot-tempel.el
@@ -69,7 +69,6 @@ START END EXPAND-ENV are all ignored."
     (ignore START END EXPAND-ENV)
     (tempel-insert (eglot-tempel--convert snippet)))
 
-
 (defun eglot-tempel--snippet-expansion-fn ()
   "An override of ‘eglot--snippet-expansion-fn’."
   #'eglot-tempel-expand-yas-snippet)
@@ -77,12 +76,16 @@ START END EXPAND-ENV are all ignored."
 ;;;###autoload
 (define-minor-mode eglot-tempel-mode
   "Toggle eglot template support by tempel."
-  :global t
-  (if eglot-tempel-mode
-       (advice-add 'eglot--snippet-expansion-fn
-                   :override #'eglot-tempel--snippet-expansion-fn)
-    (advice-remove 'eglot--snippet-expansion-fn
-                    #'eglot-tempel--snippet-expansion-fn)))
+  :init-value nil
+  :global nil
+  :lighter nil
+  (unless (advice-member-p 'eglot--snippet-expansion-fn
+                    #'eglot-tempel--snippet-expansion-fn)
+    (if eglot-tempel-mode
+	(advice-add 'eglot--snippet-expansion-fn
+                    :override #'eglot-tempel--snippet-expansion-fn)
+      (advice-remove 'eglot--snippet-expansion-fn
+                     #'eglot-tempel--snippet-expansion-fn))))
 
 (provide 'eglot-tempel)
 ;;; eglot-tempel.el ends here


### PR DESCRIPTION
* eglot-tempel-tests.el (test-numbered): (test-end):
(test-mixed):
(test-dots):
(test-choice): minor test fixes to match expectations

* eglot-tempel.el: Bump Version and dependencies
(eglot-tempel--peg): New function to parse snippet
(eglot-tempel-mode): fix advice hook